### PR TITLE
Update schemas.ts

### DIFF
--- a/packages/dewp/schemas.ts
+++ b/packages/dewp/schemas.ts
@@ -275,6 +275,7 @@ export const StatusSchema = z.object({
 	slug: z.string().describe('An alphanumeric identifier for the status.'),
 	date_floating: z
 		.boolean()
+		.optional()
 		.describe('Whether posts of this status may have floating published dates.'),
 });
 


### PR DESCRIPTION
For StatusSchema attribute 'date_floating' set optional. for compatible with Wordpress 5.x